### PR TITLE
Add check and edit YT video name for Windows file system

### DIFF
--- a/downloadVid.py
+++ b/downloadVid.py
@@ -3,11 +3,29 @@ from pytube import YouTube
 import requests
 from tqdm import tqdm
 import math
+import re
+
+
+def multi_replace_regex(string, replacements, ignore_case=False):
+    for pattern, replacement in replacements.items():
+        string = re.sub(pattern, replacement, string, flags=re.I if ignore_case else 0)
+    return string
+
+replacements = {
+    "\\\\"  :   chr(0x29F9),
+    "[/]"   :   chr(0x29F8),
+    "[:]"   :   chr(0xFF1A),
+    "[*]"   :   chr(0xFF0A),
+    "[?]"   :   chr(0xFF1F),
+    '["]'   :   chr(0xFF02),
+    "[|]"   :   chr(0xFF5C)
+}
+
 
 def download_video(video_url) -> str:
     yt = YouTube(video_url)
-    
-    filename = yt.title + ".mp4"
+
+    filename = multi_replace_regex(yt.title, replacements, False) + ".mp4"
     file_path = os.path.join("Video/", filename)
 
     #If file already exists, don't download it again

--- a/downloadVid.py
+++ b/downloadVid.py
@@ -6,9 +6,9 @@ import math
 import re
 
 
-def multi_replace_regex(string, replacements, ignore_case=False):
+def multi_replace_regex(string, replacements):
     for pattern, replacement in replacements.items():
-        string = re.sub(pattern, replacement, string, flags=re.I if ignore_case else 0)
+        string = re.sub(pattern, replacement, string)
     return string
 
 replacements = {
@@ -25,7 +25,7 @@ replacements = {
 def download_video(video_url) -> str:
     yt = YouTube(video_url)
 
-    filename = multi_replace_regex(yt.title, replacements, False) + ".mp4"
+    filename = multi_replace_regex(yt.title, replacements) + ".mp4"
     file_path = os.path.join("Video/", filename)
 
     #If file already exists, don't download it again


### PR DESCRIPTION
I found some videos title contain illegal characters in Windows file system result in video cannot be saved to `/Video` to playback
So I replace those forbidden characters `\` `/` `:` `*` `?` `"` `|` in Windows but allowed on YT video title into similar characters `⧹`  `⧸`  `：` `＊` `？` `＂` `｜`
Real example: [「ツバメ」/ YOASOBI with ミドリーズ Official Music Video](https://www.youtube.com/watch?v=qDL3zhB8-MM) saved into `「ツバメ」⧸ YOASOBI with ミドリーズ Official Music Video.mp4`
Test example: [Weird file name 「ツバメ」\ / : * ? " |](https://www.youtube.com/watch?v=ccXD5GTAC5U) saved into `Weird file name 「ツバメ」⧹ ⧸ ： ＊ ？ ＂ ｜.mp4` 
For Linux/Unix, I only know `/` is illegal and there is a closed PR https://github.com/DvorakDwarf/Colored-ASCII-Video/pull/4 that attempt to fix it but I don't have Linux/Unix to test so there is that.